### PR TITLE
fix: resolve nix deprecation warnings

### DIFF
--- a/builders/mk-vintagestory-v1.nix
+++ b/builders/mk-vintagestory-v1.nix
@@ -5,7 +5,9 @@
   makeWrapper,
   makeDesktopItem,
   copyDesktopItems,
-  xorg,
+  libX11,
+  libXi,
+  libXcursor,
   gtk2,
   sqlite,
   openal,
@@ -69,9 +71,9 @@ stdenv.mkDerivation (finalAttrs: {
       libpulseaudio
     ]
     ++ [
-      xorg.libX11
-      xorg.libXi
-      xorg.libXcursor
+      libX11
+      libXi
+      libXcursor
     ];
 
   desktopItems = [

--- a/builders/mk-vintagestory-v2.nix
+++ b/builders/mk-vintagestory-v2.nix
@@ -12,7 +12,9 @@
   libpulseaudio,
   dotnet-runtime_8,
   x11Support ? true,
-  xorg ? null,
+  libX11 ? null,
+  libXi ? null,
+  libXcursor ? null,
   waylandSupport ? false,
   wayland ? null,
   libxkbcommon ? null,
@@ -22,7 +24,9 @@
 }:
 
 assert x11Support || waylandSupport;
-assert x11Support -> xorg != null;
+assert x11Support -> libX11 != null;
+assert x11Support -> libXi != null;
+assert x11Support -> libXcursor != null;
 assert waylandSupport -> wayland != null;
 assert waylandSupport -> libxkbcommon != null;
 
@@ -69,9 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
       libpulseaudio
     ]
     ++ lib.optionals x11Support [
-      xorg.libX11
-      xorg.libXi
-      xorg.libXcursor
+      libX11
+      libXi
+      libXcursor
     ]
     ++ lib.optionals waylandSupport [
       wayland

--- a/builders/mk-vintagestory-v3.nix
+++ b/builders/mk-vintagestory-v3.nix
@@ -12,7 +12,9 @@
   libpulseaudio,
   dotnet-runtime_10,
   x11Support ? true,
-  xorg ? null,
+  libX11 ? null,
+  libXi ? null,
+  libXcursor ? null,
   waylandSupport ? false,
   wayland ? null,
   libxkbcommon ? null,
@@ -21,7 +23,9 @@
 }:
 
 assert x11Support || waylandSupport;
-assert x11Support -> xorg != null;
+assert x11Support -> libX11 != null;
+assert x11Support -> libXi != null;
+assert x11Support -> libXcursor != null;
 assert waylandSupport -> wayland != null;
 assert waylandSupport -> libxkbcommon != null;
 
@@ -64,9 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
       libpulseaudio
     ]
     ++ lib.optionals x11Support [
-      xorg.libX11
-      xorg.libXi
-      xorg.libXcursor
+      libX11
+      libXi
+      libXcursor
     ]
     ++ lib.optionals waylandSupport [
       wayland

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751637120,
-        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
         "type": "github"
       },
       "original": {

--- a/module/default.nix
+++ b/module/default.nix
@@ -75,7 +75,7 @@ in {
         };
       in ''
         ${lib.getExe' cfg.package "vintagestory-server"} \
-          ${lib.cli.toGNUCommandLineShell {} opts} \
+          ${lib.cli.toCommandLineShellGNU {} opts} \
           ${lib.concatStringsSep " " cfg.extraFlags}
       '';
 

--- a/tools/vsmodelcreator/default.nix
+++ b/tools/vsmodelcreator/default.nix
@@ -5,7 +5,8 @@
   copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
-  xorg,
+  libXxf86vm,
+  xrandr,
   libGL,
   jdk8,
   jre8,
@@ -45,8 +46,8 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${lib.getExe jre8} $out/bin/vsmodelcreator \
       --add-flags "-cp $out/share/vsmodelcreator/vsmodelcreator.jar at.vintagestory.modelcreator.Start" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath (with xorg; [libXxf86vm libGL])} \
-      --prefix PATH : ${lib.makeBinPath [xorg.xrandr]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [libXxf86vm libGL]} \
+      --prefix PATH : ${lib.makeBinPath [xrandr]}
 
     runHook postInstall
   '';


### PR DESCRIPTION
`lib.cli.toGNUCommandLineShell` has been deprecated in https://github.com/NixOS/nixpkgs/pull/404233
`xorg.*` has been deprecated in https://github.com/NixOS/nixpkgs/pull/415049

```
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
evaluation warning: lib.cli.toGNUCommandLineShell is deprecated, please use lib.cli.toCommandLineShell or lib.cli.toCommandLineShellGNU instead.
```
---
Should `flake.lock` also be updated?