### PR TITLE
feat(admin): improve UX of `vintagestory-admin`

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -113,9 +113,20 @@ in {
       # operator
       (pkgs.writeShellScriptBin "vintagestory-admin" ''
         journalctl -o cat -fu vintagestory.service & pid=$!
-        ${lib.getExe pkgs.socat} -u STDIN PIPE:/run/vintagestory.socket
 
-        kill $pid
+        # If stdin is a tty,
+        if [ -t 0 ] ; then
+          # Use readline for input
+          ${lib.getExe pkgs.socat} -u READLINE PIPE:/run/vintagestory.socket
+
+          # Supress error (and exitcode) if already killed by ^C
+          kill $pid 2>/dev/null; true
+        else
+          # Do not use readline, as it will crash if stdin isn’t a tty
+          ${lib.getExe pkgs.socat} -u STDIN PIPE:/run/vintagestory.socket
+
+          kill $pid
+        fi
       '')
     ];
 

--- a/module/default.nix
+++ b/module/default.nix
@@ -117,7 +117,15 @@ in {
         # If stdin is a tty,
         if [ -t 0 ] ; then
           # Use readline for input
-          ${lib.getExe pkgs.socat} -u READLINE PIPE:/run/vintagestory.socket
+
+          historyfile="''${XDG_STATE_DIR:-$HOME/.local/state}/vintagestory-admin.history"
+          mkdir -p "$(dirname "$historyfile")"
+
+          ${lib.getExe pkgs.socat} -u READLINE,history="$historyfile" PIPE:/run/vintagestory.socket
+
+          # Keep only the latest occurance of duplicate lines in the history file
+          # Keep only 500 lines of history
+          tac "$historyfile" | awk '!x[$0]++' | tac | tail -n 500 | ${lib.getExe' pkgs.moreutils "sponge"} "$historyfile"
 
           # Supress error (and exitcode) if already killed by ^C
           kill $pid 2>/dev/null; true

--- a/module/default.nix
+++ b/module/default.nix
@@ -112,7 +112,7 @@ in {
       # At the moment this script is also the only way to make a player an
       # operator
       (pkgs.writeShellScriptBin "vintagestory-admin" ''
-        journalctl -o cat -fu vintagestory.service & pid=$!
+        journalctl -o cat -fu vintagestory.service 2>/dev/null & pid=$!
 
         # If stdin is a tty,
         if [ -t 0 ] ; then


### PR DESCRIPTION
feat(admin): use readline for interactive input

Allow for richer editing, command history, ^R searching, and other
features that can make entering commands far more pleasant

---

feat(admin): supress journalctl warnings

Redirect journalctl stderr to `/dev/null` to discard messages like the
following:
`Journal file /var/log/journal/[...].journal~ is truncated, ignoring file.`

---

feat(admin): remember interactive console history

Allow for easy ^R searching of commonly used commands

---

module/default.nix | 25 ++++++++++++++++++++++---
1 file changed, 22 insertions(+), 3 deletions(-)

I mostly made this to solve my own frustrations with needing to frequently re-type the same commands.

If the console history isn’t desired, let me know and I can easily drop that from the PR.